### PR TITLE
Added company_zipcode and company_street to webapp

### DIFF
--- a/app/views/companies/_form.html.haml
+++ b/app/views/companies/_form.html.haml
@@ -25,6 +25,12 @@
     = f.label :city
     = f.text_field :city
   .field
+    = f.label :building_street
+    = f.text_field :building_street
+  .field
+    = f.label :building_zipcode
+    = f.text_field :building_zipcode
+  .field
     = f.label :email
     = f.text_field :email
   .field

--- a/app/views/companies/index.html.haml
+++ b/app/views/companies/index.html.haml
@@ -8,6 +8,8 @@
     %th Street
     %th Zip code
     %th City
+    %th Building street
+    %th Building Zip code
     %th Email
     %th Web
     %th Bank name
@@ -27,6 +29,8 @@
       %td= company.street
       %td= company.zip_code
       %td= company.city
+      %td= company.building_street
+      %td= company.building_zipcode
       %td= company.email
       %td= company.web
       %td= company.bank_name

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -16,8 +16,11 @@
   %b Zip code:
   = @company.zip_code
 %p
-  %b City:
-  = @company.city
+  %b Building street:
+  = @company.building_street
+%p
+  %b Building Zip code:
+  = @company.building_zipcode
 %p
   %b Email:
   = @company.email


### PR DESCRIPTION
 Since it's used in generated PDFs.

If you seed your db those fields will be filled with "Musterstraße 14" and "xxxxx" and this will appear in the PDFs generated.

The pull request adds the missing fields to modify and view those entries into the app.